### PR TITLE
chore: upgrade flutter and dependencies

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,11 +22,8 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
+    namespace "com.example.example"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
@@ -67,5 +65,4 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.6.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()
@@ -26,6 +13,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register("clean", Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+}
+
+include ":app"

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +275,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -350,7 +353,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -399,7 +402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,11 +44,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/ui/bottom_sheets/notice_sheet/notice_sheet.dart
+++ b/example/lib/ui/bottom_sheets/notice_sheet/notice_sheet.dart
@@ -7,15 +7,22 @@ class NoticeSheet extends StatelessWidget {
   final Function(SheetResponse)? completer;
   final SheetRequest request;
   const NoticeSheet({
-    Key? key,
+    super.key,
     required this.completer,
     required this.request,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(10),
+        ),
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -33,13 +40,6 @@ class NoticeSheet extends StatelessWidget {
           ),
           verticalSpaceLarge,
         ],
-      ),
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(10),
-          topRight: Radius.circular(10),
-        ),
       ),
     );
   }

--- a/example/lib/ui/dialogs/info_alert/info_alert_dialog.dart
+++ b/example/lib/ui/dialogs/info_alert/info_alert_dialog.dart
@@ -10,10 +10,10 @@ class InfoAlertDialog extends StatelessWidget {
   final Function(DialogResponse) completer;
 
   const InfoAlertDialog({
-    Key? key,
+    super.key,
     required this.request,
     required this.completer,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -75,6 +75,10 @@ class InfoAlertDialog extends StatelessWidget {
                 height: 50,
                 width: double.infinity,
                 alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: Colors.black,
+                  borderRadius: BorderRadius.circular(10),
+                ),
                 child: const Text(
                   'Got it',
                   style: TextStyle(
@@ -82,10 +86,6 @@ class InfoAlertDialog extends StatelessWidget {
                     fontWeight: FontWeight.bold,
                     fontSize: 16,
                   ),
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.black,
-                  borderRadius: BorderRadius.circular(10),
                 ),
               ),
             )

--- a/example/lib/ui/views/home/home_view.dart
+++ b/example/lib/ui/views/home/home_view.dart
@@ -6,7 +6,7 @@ import 'package:stacked_hooks_example/ui/common/ui_helpers.dart';
 import 'home_viewmodel.dart';
 
 class HomeView extends StackedView<HomeViewModel> {
-  const HomeView({Key? key}) : super(key: key);
+  const HomeView({super.key});
 
   @override
   Widget builder(BuildContext context, HomeViewModel viewModel, Widget? child) {
@@ -38,23 +38,23 @@ class HomeView extends StackedView<HomeViewModel> {
                   children: [
                     MaterialButton(
                       color: kcDarkGreyColor,
+                      onPressed: viewModel.goToWithStackedHook,
                       child: const Text(
                         'With Stacked Hook',
                         style: TextStyle(
                           color: Colors.white,
                         ),
                       ),
-                      onPressed: viewModel.goToWithStackedHook,
                     ),
                     MaterialButton(
                       color: kcDarkGreyColor,
+                      onPressed: viewModel.goToWithoutStackedHook,
                       child: const Text(
                         'Without Stacked Hook',
                         style: TextStyle(
                           color: Colors.white,
                         ),
                       ),
-                      onPressed: viewModel.goToWithoutStackedHook,
                     ),
                   ],
                 )

--- a/example/lib/ui/views/startup/startup_view.dart
+++ b/example/lib/ui/views/startup/startup_view.dart
@@ -6,7 +6,7 @@ import 'package:stacked_hooks_example/ui/common/ui_helpers.dart';
 import 'startup_viewmodel.dart';
 
 class StartupView extends StackedView<StartupViewModel> {
-  const StartupView({Key? key}) : super(key: key);
+  const StartupView({super.key});
 
   @override
   Widget builder(
@@ -55,6 +55,6 @@ class StartupView extends StackedView<StartupViewModel> {
   }
 
   @override
-  void onModelReady(StartupViewModel viewModel) => SchedulerBinding.instance
+  void onViewModelReady(StartupViewModel viewModel) => SchedulerBinding.instance
       .addPostFrameCallback((timeStamp) => viewModel.runStartupLogic());
 }

--- a/example/lib/ui/views/with_stacked_hook/with_stacked_hook_view.dart
+++ b/example/lib/ui/views/with_stacked_hook/with_stacked_hook_view.dart
@@ -6,7 +6,7 @@ import 'package:stacked_hooks/stacked_hooks.dart';
 import 'with_stacked_hook_viewmodel.dart';
 
 class WithStackedHookView extends StackedView<WithStackedHookViewModel> {
-  const WithStackedHookView({Key? key}) : super(key: key);
+  const WithStackedHookView({super.key});
 
   @override
   Widget builder(

--- a/example/lib/ui/views/without_stacked_hook/without_stacked_hook_view.dart
+++ b/example/lib/ui/views/without_stacked_hook/without_stacked_hook_view.dart
@@ -4,7 +4,7 @@ import 'package:stacked/stacked.dart';
 import 'without_stacked_hook_viewmodel.dart';
 
 class WithoutStackedHookView extends StackedView<WithoutStackedHookViewModel> {
-  const WithoutStackedHookView({Key? key}) : super(key: key);
+  const WithoutStackedHookView({super.key});
 
   @override
   Widget builder(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.8
 
   stacked:
   stacked_hooks:
@@ -48,10 +48,10 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.2
+  flutter_lints: ^6.0.0
   build_runner:
   stacked_generator:
-  mockito: ^5.4.4
+  mockito: ^5.5.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/example/test/helpers/test_helpers.mocks.dart
+++ b/example/test/helpers/test_helpers.mocks.dart
@@ -554,10 +554,12 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
     String? description,
     String? cancelTitle,
     _i6.Color? cancelTitleColor,
-    String? buttonTitle = r'Ok',
+    String buttonTitle = r'Ok',
     _i6.Color? buttonTitleColor,
-    bool? barrierDismissible = false,
+    bool barrierDismissible = false,
     _i2.DialogPlatform? dialogPlatform,
+    _i4.GlobalKey<_i4.NavigatorState>? navigatorKey,
+    _i4.RouteSettings? routeSettings,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -572,6 +574,8 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
             #buttonTitleColor: buttonTitleColor,
             #barrierDismissible: barrierDismissible,
             #dialogPlatform: dialogPlatform,
+            #navigatorKey: navigatorKey,
+            #routeSettings: routeSettings,
           },
         ),
         returnValue: _i5.Future<_i2.DialogResponse<dynamic>?>.value(),
@@ -599,6 +603,11 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
     bool? useSafeArea = true,
     dynamic customData,
     R? data,
+    _i4.GlobalKey<_i4.NavigatorState>? navigatorKey,
+    _i4.RouteSettings? routeSettings,
+    _i4.Widget Function(_i4.BuildContext, _i4.Animation<double>,
+            _i4.Animation<double>, _i4.Widget)?
+        transitionBuilder,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -623,6 +632,9 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
             #useSafeArea: useSafeArea,
             #customData: customData,
             #data: data,
+            #navigatorKey: navigatorKey,
+            #routeSettings: routeSettings,
+            #transitionBuilder: transitionBuilder,
           },
         ),
         returnValue: _i5.Future<_i2.DialogResponse<T>?>.value(),
@@ -633,12 +645,13 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
   _i5.Future<_i2.DialogResponse<dynamic>?> showConfirmationDialog({
     String? title,
     String? description,
-    String? cancelTitle = r'Cancel',
+    String cancelTitle = r'Cancel',
     _i6.Color? cancelTitleColor,
-    String? confirmationTitle = r'Ok',
+    String confirmationTitle = r'Ok',
     _i6.Color? confirmationTitleColor,
-    bool? barrierDismissible = false,
+    bool barrierDismissible = false,
     _i2.DialogPlatform? dialogPlatform,
+    _i4.RouteSettings? routeSettings,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -653,6 +666,7 @@ class MockDialogService extends _i1.Mock implements _i2.DialogService {
             #confirmationTitleColor: confirmationTitleColor,
             #barrierDismissible: barrierDismissible,
             #dialogPlatform: dialogPlatform,
+            #routeSettings: routeSettings,
           },
         ),
         returnValue: _i5.Future<_i2.DialogResponse<dynamic>?>.value(),

--- a/lib/src/_stacked_hook_view.dart
+++ b/lib/src/_stacked_hook_view.dart
@@ -6,7 +6,8 @@ import 'package:provider/provider.dart';
 /// build
 abstract class StackedHookView<T> extends HookWidget {
   final bool reactive;
-  const StackedHookView({Key? key, this.reactive = true}) : super(key: key);
+
+  const StackedHookView({super.key, this.reactive = true});
 
   @override
   Widget build(BuildContext context) => builder(
@@ -21,7 +22,8 @@ abstract class StackedHookView<T> extends HookWidget {
     'This widget will be removed by March 2023, please use the StackedHookView instead')
 abstract class HookViewModelWidget<T> extends HookWidget {
   final bool reactive;
-  const HookViewModelWidget({Key? key, this.reactive = true}) : super(key: key);
+
+  const HookViewModelWidget({super.key, this.reactive = true});
 
   @override
   Widget build(BuildContext context) => buildViewModelWidget(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.20.5
-  provider: ^6.1.2
+  flutter_hooks: ^0.21.3+1
+  provider: ^6.1.5+1
 
 dev_dependencies:
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 
@@ -24,32 +24,32 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+# To add assets to your package, add an assets section, like this:
+# assets:
+#  - images/a_dot_burr.jpeg
+#  - images/a_dot_ham.jpeg
+#
+# For details regarding assets in packages, see
+# https://flutter.dev/assets-and-images/#from-packages
+#
+# An image asset can refer to one or more resolution-specific "variants", see
+# https://flutter.dev/assets-and-images/#resolution-aware.
+# To add custom fonts to your package, add a fonts section here,
+# in this "flutter" section. Each entry in this list should have a
+# "family" key with the font family name, and a "fonts" key with a
+# list giving the asset and other descriptors for the font. For
+# example:
+# fonts:
+#   - family: Schyler
+#     fonts:
+#       - asset: fonts/Schyler-Regular.ttf
+#       - asset: fonts/Schyler-Italic.ttf
+#         style: italic
+#   - family: Trajan Pro
+#     fonts:
+#       - asset: fonts/TrajanPro.ttf
+#       - asset: fonts/TrajanPro_Bold.ttf
+#         weight: 700
+#
+# For details regarding fonts in packages, see
+# https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
**Upgrade Flutter and dependencies**

This commit upgrades the project to a newer Flutter version and updates various dependencies.

**Dependency Updates:**
- Bumps `flutter_hooks` to `^0.21.3+1`
- Bumps `provider` to `^6.1.5+1`
- Bumps `flutter_lints` to `^6.0.0`
- Bumps `cupertino_icons` to `^1.0.8`
- Bumps `mockito` to `^5.5.0`

**Android:**
- Upgrades Gradle to version 8.14.1.
- Refactors `settings.gradle` to use the modern plugin management block.
- Removes the top-level `buildscript` block from `build.gradle`.
- Updates `app/build.gradle` to use the plugins block and adds the `namespace`.

**iOS:**
- Sets the iOS deployment target to 13.0.
- Updates Xcode project settings (`project.pbxproj`) and scheme files.
- Uses `@main` attribute instead of `@UIApplicationMain` in `AppDelegate.swift`.

**General:**
- Adds `.build/` and `.swiftpm/` to the example's `.gitignore`.
- Updates generated mock files to match new dependency versions.
- Passes `super.key` in `StackedHookView` and `HookViewModelWidget` constructors.