### PR TITLE
chore(deps): update actions/checkout action to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Package and Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.REPO_DEPLOYMENT_TOKEN }}
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           token: ${{ secrets.REPO_DEPLOYMENT_TOKEN }}
+          persist-credentials: false
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - run: flutter pub get
       - name: release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v5
         with:
           extra_plugins: |
             @semantic-release/exec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     name: Linting and Testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
       - run: flutter pub get
-      - run: dart format --fix --set-exit-if-changed .
+      - run: dart format --set-exit-if-changed .
       # - run: flutter analyze
       # - run: flutter test --coverage
       # - name: Setup LCOV


### PR DESCRIPTION
**Update actions/checkout action to v5**

- Updates the `actions/checkout` GitHub Action from v4 to v5 in both the `test.yml` and `release.yml` workflows.
- Removes the `--fix` flag from the `dart format` command in the `test.yml` workflow, retaining `--set-exit-if-changed`.
- Updates the `cycjimmy/semantic-release-action` to v5.
- Sets `persist-credentials: false` in the checkout action.


<img width="1328" height="430" alt="Screenshot 2568-10-17 at 02 07 46" src="https://github.com/user-attachments/assets/9876a39f-85aa-4058-99b3-b8e3f4a33c04" />


<img width="1328" height="401" alt="Screenshot 2568-10-17 at 02 07 55" src="https://github.com/user-attachments/assets/d0e7842a-8a82-418c-a8e5-92fc88b29e3c" />





